### PR TITLE
Fix adapter initialization

### DIFF
--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -153,10 +153,18 @@ export class Namespace<
 	 *
 	 * @private
 	 */
-	_initAdapter(): void {
-		// @ts-ignore
-		this.adapter = new (this.server.adapter()!)(this);
-	}
+        _initAdapter(): void {
+                let AdapterConstructor: any;
+                if (typeof (this.server as any).adapter === 'function') {
+                        AdapterConstructor = (this.server as any).adapter();
+                } else {
+                        AdapterConstructor = Adapter;
+                }
+                if (AdapterConstructor) {
+                        // @ts-ignore
+                        this.adapter = new AdapterConstructor(this);
+                }
+        }
 
 	/**
 	 * Registers a middleware, which is a function that gets executed for every incoming {@link Socket}.

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -93,11 +93,10 @@ export class Socket<
 		// previousSession?: Session,
 	) {
 		super();
-		this.server = nsp.server;
-		this.adapter = nsp.adapter;
-		this.id = client.conn.id;
-		this.adapter = this.nsp.adapter;
-		this.handshake = this.buildHandshake(auth);
+                this.server = nsp.server;
+                this.adapter = nsp.adapter;
+                this.id = client.conn.id;
+               this.handshake = this.buildHandshake(auth);
 
 		// prevents crash when the socket receives an "error" event without listener
 		this.on('error', () => {});


### PR DESCRIPTION
## Summary
- prevent crashes when adapter is missing on the server
- remove duplicate adapter assignment in `Socket`

## Testing
- `npm test` *(fails: `namespace.handleConnection is not a function`)*

------
https://chatgpt.com/codex/tasks/task_e_6840a6366900832bb1cc53b174d48f79