### PR TITLE
Add integration tests

### DIFF
--- a/test/integration/connection/connect.test.ts
+++ b/test/integration/connection/connect.test.ts
@@ -1,0 +1,35 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+
+// Connection tests
+
+describe('Connection', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should successfully connect client to server', async () => {
+    const io = await createServer();
+    const client = createClient();
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Connection timeout')), 5000);
+
+      client.on('connect', () => {
+        clearTimeout(timeout);
+        expect(client.connected).toBe(true);
+        expect(client.id).toBeDefined();
+        resolve();
+      });
+
+      client.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  });
+});

--- a/test/integration/connection/disconnect.test.ts
+++ b/test/integration/connection/disconnect.test.ts
@@ -1,0 +1,39 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+
+// Client initiated disconnection
+
+describe('Connection - Disconnection', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should handle disconnection', async () => {
+    const io = await createServer();
+    const client = createClient();
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Disconnection timeout')), 5000);
+
+      client.on('connect', () => {
+        expect(client.connected).toBe(true);
+        client.disconnect();
+      });
+
+      client.on('disconnect', () => {
+        clearTimeout(timeout);
+        expect(client.connected).toBe(false);
+        resolve();
+      });
+
+      client.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  });
+});

--- a/test/integration/connection/multiple-clients.test.ts
+++ b/test/integration/connection/multiple-clients.test.ts
@@ -1,0 +1,47 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+
+// Multiple clients connection
+
+describe('Connection - Multiple clients', () => {
+  const { createServer, createClient, cleanup, testEnv } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should handle multiple clients', async () => {
+    const io = await createServer();
+    const client1 = createClient();
+    const client2 = createClient();
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Multiple clients timeout')), 5000);
+      let connectedCount = 0;
+
+      const checkConnections = () => {
+        connectedCount++;
+        if (connectedCount === 2) {
+          clearTimeout(timeout);
+          expect(testEnv.clientsConnectedCount).toBe(2);
+          expect(client1.id).not.toBe(client2.id);
+          resolve();
+        }
+      };
+
+      client1.on('connect', checkConnections);
+      client2.on('connect', checkConnections);
+
+      client1.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+      client2.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  });
+});

--- a/test/integration/connection/server-disconnect.test.ts
+++ b/test/integration/connection/server-disconnect.test.ts
@@ -1,0 +1,37 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+import type { Socket } from '../../../src/socket';
+
+describe('Connection - Server side disconnect', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should handle server-side disconnection', async () => {
+    const io = await createServer();
+    const client = createClient();
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Server disconnection timeout')), 5000);
+
+      io.on('connection', (socket: Socket) => {
+        socket.disconnect();
+      });
+
+      client.on('disconnect', () => {
+        clearTimeout(timeout);
+        expect(client.connected).toBe(false);
+        resolve();
+      });
+
+      client.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  });
+});

--- a/test/integration/events/ack.test.ts
+++ b/test/integration/events/ack.test.ts
@@ -1,0 +1,45 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+import type { Socket } from '../../../src/socket';
+
+describe('Events - Acknowledgments', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should handle acknowledgments', async () => {
+    const io = await createServer();
+    const client = createClient();
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('ACK timeout')), 5000);
+
+      io.on('connection', (socket: Socket) => {
+        socket.on('test_ack', (data: string, callback: Function) => {
+          callback(`ACK: ${data}`);
+        });
+      });
+
+      client.on('connect', () => {
+        client.emit('test_ack', 'ack test', (response: string) => {
+          clearTimeout(timeout);
+          try {
+            expect(response).toBe('ACK: ack test');
+            resolve();
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+
+      client.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  });
+});

--- a/test/integration/events/binary.test.ts
+++ b/test/integration/events/binary.test.ts
@@ -1,0 +1,46 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+import type { Socket } from '../../../src/socket';
+
+describe('Events - Binary', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should handle binary data', async () => {
+    const io = await createServer();
+    const client = createClient();
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Binary data timeout')), 5000);
+
+      io.on('connection', (socket: Socket) => {
+        socket.on('binary_test', (data: Buffer) => {
+          expect(data).toBeInstanceOf(Buffer);
+          socket.emit('binary_response', Buffer.from('response'));
+        });
+      });
+
+      client.on('binary_response', (response: Buffer) => {
+        clearTimeout(timeout);
+        expect(response).toBeInstanceOf(Buffer);
+        expect(response.toString()).toBe('response');
+        resolve();
+      });
+
+      client.on('connect', () => {
+        const binaryData = Buffer.from('test binary data');
+        client.emit('binary_test', binaryData);
+      });
+
+      client.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  });
+});

--- a/test/integration/events/events.test.ts
+++ b/test/integration/events/events.test.ts
@@ -1,0 +1,43 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+import type { Socket } from '../../../src/socket';
+
+describe('Events', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should exchange events between client and server', async () => {
+    const io = await createServer();
+    const client = createClient();
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Event exchange timeout')), 5000);
+
+      io.on('connection', (socket: Socket) => {
+        socket.on('test_event', (data: string) => {
+          socket.emit('test_response', `Server received: ${data}`);
+        });
+      });
+
+      client.on('test_response', (response: string) => {
+        clearTimeout(timeout);
+        expect(response).toBe('Server received: hello from client');
+        resolve();
+      });
+
+      client.on('connect', () => {
+        client.emit('test_event', 'hello from client');
+      });
+
+      client.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  });
+});

--- a/test/integration/handshake/handshake.test.ts
+++ b/test/integration/handshake/handshake.test.ts
@@ -1,0 +1,36 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+import type { Socket } from '../../../src/socket';
+
+describe('Handshake', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should expose handshake details', async () => {
+    const io = await createServer();
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Handshake timeout')), 5000);
+
+      io.on('connection', (socket: Socket) => {
+        clearTimeout(timeout);
+        try {
+          expect(socket.handshake).toBeDefined();
+          expect(typeof socket.handshake.time).toBe('string');
+          expect(socket.handshake.auth).toEqual({ token: 'abc' });
+          expect(typeof socket.handshake.query).toBe('function');
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+      createClient({ auth: { token: 'abc' }, query: { foo: 'bar' } });
+    });
+  });
+});

--- a/test/integration/index.test.ts
+++ b/test/integration/index.test.ts
@@ -7,3 +7,7 @@ import './rooms/rooms.test';
 import './namespaces/namespaces.test';
 import './connection/disconnect.test';
 import './connection/server-disconnect.test';
+import './handshake/handshake.test';
+import './middleware/middleware.test';
+import './socket-middleware/socket-middleware.test';
+import './socket-timeout/socket-timeout.test';

--- a/test/integration/index.test.ts
+++ b/test/integration/index.test.ts
@@ -1,0 +1,9 @@
+import './connection/connect.test';
+import './events/events.test';
+import './events/ack.test';
+import './events/binary.test';
+import './connection/multiple-clients.test';
+import './rooms/rooms.test';
+import './namespaces/namespaces.test';
+import './connection/disconnect.test';
+import './connection/server-disconnect.test';

--- a/test/integration/middleware/middleware.test.ts
+++ b/test/integration/middleware/middleware.test.ts
@@ -1,0 +1,68 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+import type { Socket } from '../../../src/socket';
+
+describe('Server middleware', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should call middleware functions before connection', async () => {
+    const io = await createServer();
+    let run = 0;
+    io.use((socket: Socket, next) => {
+      run++;
+      next();
+    });
+    io.use((socket: Socket, next) => {
+      run++;
+      next();
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      const client = createClient();
+      const timeout = setTimeout(() => reject(new Error('Middleware timeout')), 5000);
+
+      client.on('connect', () => {
+        clearTimeout(timeout);
+        try {
+          expect(run).toBe(2);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+      client.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  });
+
+  test('should pass error from middleware', async () => {
+    const io = await createServer();
+    io.use((socket: Socket, next) => {
+      next(new Error('Auth error'));
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      const client = createClient();
+      const timeout = setTimeout(() => reject(new Error('Middleware error timeout')), 5000);
+
+      client.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        try {
+          expect(err.message).toBe('Auth error');
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+});

--- a/test/integration/namespaces/namespaces.test.ts
+++ b/test/integration/namespaces/namespaces.test.ts
@@ -1,0 +1,40 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+import type { Socket } from '../../../src/socket';
+
+describe('Namespaces', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should handle namespaces', async () => {
+    const io = await createServer();
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Namespace timeout')), 5000);
+
+      const chatNamespace = io.of('/chat');
+
+      chatNamespace.on('connection', (socket: Socket) => {
+        clearTimeout(timeout);
+        expect(socket.nsp.name).toBe('/chat');
+        resolve();
+      });
+
+      const client = createClient({ namespace: '/chat' });
+
+      client.on('connect', () => {
+        expect((client as any).nsp).toBe('/chat');
+      });
+
+      client.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  });
+});

--- a/test/integration/rooms/rooms.test.ts
+++ b/test/integration/rooms/rooms.test.ts
@@ -1,0 +1,38 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+import type { Socket } from '../../../src/socket';
+
+describe('Rooms', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should handle room operations', async () => {
+    const io = await createServer();
+    const client = createClient();
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Room operations timeout')), 5000);
+
+      io.on('connection', (socket: Socket) => {
+        socket.join('test-room');
+        socket.to('test-room').emit('room_broadcast', 'Hello room!');
+      });
+
+      client.on('room_broadcast', (message: string) => {
+        clearTimeout(timeout);
+        expect(message).toBe('Hello room!');
+        resolve();
+      });
+
+      client.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  });
+});

--- a/test/integration/socket-middleware/socket-middleware.test.ts
+++ b/test/integration/socket-middleware/socket-middleware.test.ts
@@ -1,0 +1,87 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+import type { Socket } from '../../../src/socket';
+
+describe('Socket middleware', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should call middleware functions', async () => {
+    const io = await createServer();
+    const client = createClient({ autoConnect: false });
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Middleware timeout')), 5000);
+
+      io.on('connection', (socket: Socket) => {
+        let run = 0;
+        socket.use((event, next) => {
+          expect(event).toEqual(['join', 'room1']);
+          event.unshift('wrapped');
+          run++;
+          next();
+        });
+        socket.use((event, next) => {
+          expect(event).toEqual(['wrapped', 'join', 'room1']);
+          run++;
+          next();
+        });
+        socket.on('wrapped', (data1: string, data2: string) => {
+          clearTimeout(timeout);
+          try {
+            expect(data1).toBe('join');
+            expect(data2).toBe('room1');
+            expect(run).toBe(2);
+            resolve();
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+
+      client.on('connect', () => {
+        client.emit('join', 'room1');
+      });
+
+      client.on('connect_error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+
+      client.connect();
+    });
+  });
+
+  test('should pass errors from middleware', async () => {
+    const io = await createServer();
+    const client = createClient({ autoConnect: false });
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Middleware error timeout')), 5000);
+
+      io.on('connection', (socket: Socket) => {
+        socket.use((event, next) => {
+          next(new Error('Authentication error'));
+        });
+        socket.on('error', (err) => {
+          clearTimeout(timeout);
+          try {
+            expect(err).toBeInstanceOf(Error);
+            expect(err.message).toBe('Authentication error');
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+
+      client.on('connect_error', () => {});
+      client.connect();
+    });
+  });
+});

--- a/test/integration/socket-timeout/socket-timeout.test.ts
+++ b/test/integration/socket-timeout/socket-timeout.test.ts
@@ -1,0 +1,60 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { TestEnvironment } from '../../utils/test-env';
+import type { Socket } from '../../../src/socket';
+
+describe('Socket timeout', () => {
+  const { createServer, createClient, cleanup } = new TestEnvironment({ tls: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('should timeout if client does not ACK', async () => {
+    const io = await createServer();
+    const client = createClient();
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timeout test failed')), 5000);
+
+      io.on('connection', (socket: Socket) => {
+        socket.timeout(50).emit('unknown', (err: Error) => {
+          clearTimeout(timeout);
+          try {
+            expect(err).toBeInstanceOf(Error);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+    });
+  });
+
+  test('should not timeout if ACK is received', async () => {
+    const io = await createServer();
+    const client = createClient();
+
+    client.on('echo', (arg: number, cb: Function) => {
+      cb(arg);
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timeout ack test failed')), 5000);
+
+      io.on('connection', (socket: Socket) => {
+        socket.timeout(100).emit('echo', 42, (err: Error | null, value?: number) => {
+          clearTimeout(timeout);
+          try {
+            expect(err).toBeNull();
+            expect(value).toBe(42);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+    });
+  });
+});

--- a/test/utils/test-env.ts
+++ b/test/utils/test-env.ts
@@ -11,10 +11,12 @@ export interface TestServerConfig {
 }
 
 export interface TestClientConfig {
-	namespace?: string;
-	transports?: string[];
-	timeout?: number;
-	autoConnect?: boolean;
+        namespace?: string;
+        transports?: string[];
+        timeout?: number;
+        autoConnect?: boolean;
+        auth?: Record<string, any>;
+        query?: Record<string, any>;
 }
 
 export class TestEnvironment {
@@ -98,16 +100,18 @@ export class TestEnvironment {
 			throw new Error('Server must be created first before creating clients');
 		}
 
-		const namespace = clientConfig.namespace || '/';
-		const socket = clientIO(this.serverUrl + namespace, {
-			path: '/ws',
-			transports: (clientConfig.transports as any) || ['websocket'],
-			timeout: clientConfig.timeout || 10000,
-			autoConnect: clientConfig.autoConnect !== false,
-			forceNew: true,
-			upgrade: false,
-			rememberUpgrade: true,
-		});
+               const namespace = clientConfig.namespace || '/';
+               const socket = clientIO(this.serverUrl + namespace, {
+                        path: '/ws',
+                        transports: (clientConfig.transports as any) || ['websocket'],
+                        timeout: clientConfig.timeout || 10000,
+                        autoConnect: clientConfig.autoConnect !== false,
+                        forceNew: true,
+                        upgrade: false,
+                        rememberUpgrade: true,
+                        auth: clientConfig.auth,
+                        query: clientConfig.query,
+                });
 
 		this.clients.push(socket);
 		return socket;


### PR DESCRIPTION
## Summary
- add integration test suite covering connection, event exchange, acknowledgements, rooms, namespaces, and more
- index file imports all integration tests so the suite can be run all at once
- use TestEnvironment with TLS disabled to avoid missing certificate errors

## Testing
- `bun test test/integration/index.test.ts --timeout 15000` *(fails: Binary data timeout, Room operations timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684113a22a18832bb369f2d2c14628ea